### PR TITLE
Call model training methods using function arguments, not sys.argv

### DIFF
--- a/src/bindings/pygaia/scripts/classification/generate_classification_project.py
+++ b/src/bindings/pygaia/scripts/classification/generate_classification_project.py
@@ -15,7 +15,7 @@
 # FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
 # details.
 #
-# You should have received a copy of the Affero GNU General Public License     
+# You should have received a copy of the Affero GNU General Public License
 # version 3 along with this program. If not, see http://www.gnu.org/licenses/
 
 
@@ -29,27 +29,11 @@ import gaia2.fastyaml as yaml
 
 PROJECT_TEMPLATE = open(join(filedir(), 'classification_project_template.yaml')).read()
 
-
-
-def generateProject():
-    parser = OptionParser(usage = '%prog [options] groundtruth_file filelist_file project_file datasets_dir results_dir')
-
-    options, args = parser.parse_args()
-
-    try:
-        groundtruth_file = args[0]
-        filelist_file = args[1]
-        project_file = args[2]
-        datasets_dir = args[3]
-        results_dir = args[4]
-    except:
-        parser.print_help()
-        sys.exit(1)
-
+def generateProject(groundtruth_file, filelist_file, project_file, datasets_dir, results_dir):
     gt = yaml.load(open(groundtruth_file, 'r'))
     try:
         className = gt['className']
-        groundTruth = gt['groundTruth']   
+        groundTruth = gt['groundTruth']
     except:
         print groundtruth_file, "groundtruth file has incorrect format"
         sys.exit(2)
@@ -59,14 +43,14 @@ def generateProject():
     gt_trackids = groundTruth.keys()
     fl_trackids = fl.keys()
 
-    # check that there are no dublicate ids 
+    # check that there are no dublicate ids
     if len(gt_trackids) != len(set(gt_trackids)):
         print groundtruth_file, "contains dublicate track ids"
         sys.exit(3)
-    
+
     if len(fl_trackids) != len(set(fl_trackids)):
         print filelist_file, "contains dublicate track ids"
-        sys.exit(3)  
+        sys.exit(3)
 
     # check if filelist is consistent with groundtruth (no files missing)
     if set(gt_trackids) != set(fl_trackids):
@@ -84,7 +68,20 @@ def generateProject():
     print 'Successfully written', project_file
 
 
-
 if __name__ == '__main__':
-    generateProject()
+    parser = OptionParser(usage = '%prog [options] groundtruth_file filelist_file project_file datasets_dir results_dir')
+
+    options, args = parser.parse_args()
+
+    try:
+        groundtruth_file = args[0]
+        filelist_file = args[1]
+        project_file = args[2]
+        datasets_dir = args[3]
+        results_dir = args[4]
+    except:
+        parser.print_help()
+        sys.exit(1)
+
+    generateProject(groundtruth_file, filelist_file, project_file, datasets_dir, results_dir)
 

--- a/src/bindings/pygaia/scripts/classification/json_to_sig.py
+++ b/src/bindings/pygaia/scripts/classification/json_to_sig.py
@@ -15,32 +15,14 @@
 # FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
 # details.
 #
-# You should have received a copy of the Affero GNU General Public License     
+# You should have received a copy of the Affero GNU General Public License
 # version 3 along with this program. If not, see http://www.gnu.org/licenses/
 
 import sys, os.path, json
 import gaia2.fastyaml as yaml
 from optparse import OptionParser
 
-
-def convertJsonToSig():
-    parser = OptionParser(usage = '%prog [options] filelist_file result_filelist_file\n' +
-"""
-Converts json files found in filelist_file into *.sig yaml files compatible with
-Gaia. The result files are written to the same directory where original files were 
-located.
-"""
-        )
-
-    options, args = parser.parse_args()
-
-    try:
-        filelist_file = args[0]
-        result_filelist_file = args[1]
-    except:
-        parser.print_help()
-        sys.exit(1)
-
+def convertJsonToSig(filelist_file, result_filelist_file):
     fl = yaml.load(open(filelist_file, 'r'))
 
     result_fl = fl
@@ -57,19 +39,38 @@ located.
                 del data['metadata']['audio_properties']['sample_rate']
 
             sig_file = os.path.splitext(json_file)[0] + '.sig'
-            
-            yaml.dump(data, open(sig_file, 'w'))           
+
+            yaml.dump(data, open(sig_file, 'w'))
             result_fl[trackid] = sig_file
 
         except:
             errors += [json_file]
 
     yaml.dump(result_fl, open(result_filelist_file, 'w'))
-    
+
     print "Failed to convert", len(errors), "files:"
     for e in errors:
         print e
-    return len(errors)
+
+    return len(errors) == 0
 
 if __name__ == '__main__':
-    convertJsonToSig()
+    parser = OptionParser(usage = '%prog [options] filelist_file result_filelist_file\n' +
+"""
+Converts json files found in filelist_file into *.sig yaml files compatible with
+Gaia. The result files are written to the same directory where original files were
+located.
+"""
+        )
+
+    options, args = parser.parse_args()
+
+    try:
+        filelist_file = args[0]
+        result_filelist_file = args[1]
+    except:
+        parser.print_help()
+        sys.exit(1)
+
+    convertJsonToSig(filelist_file, result_filelist_file)
+

--- a/src/bindings/pygaia/scripts/classification/run_tests.py
+++ b/src/bindings/pygaia/scripts/classification/run_tests.py
@@ -15,7 +15,7 @@
 # FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
 # details.
 #
-# You should have received a copy of the Affero GNU General Public License     
+# You should have received a copy of the Affero GNU General Public License
 # version 3 along with this program. If not, see http://www.gnu.org/licenses/
 
 
@@ -29,20 +29,10 @@ from optparse import OptionParser
 
 debugLevel = logging.INFO
 
-def runTests():
-    parser = OptionParser(usage = '%prog [options] project_file')
-
-    options, args = parser.parse_args()
-
-    try:
-        project_file = args[0]
-    except:
-        parser.print_help()
-        sys.exit(1)
-
+def runTests(project_file):
     # open the yaml file describing the analysis to perform
     try:
-        project_file = os.path.abspath(sys.argv[1])
+        project_file = os.path.abspath(project_file)
     except:
         print 'ERROR: You need to specify a yaml project file...'
         print 'Exiting...'
@@ -55,6 +45,7 @@ def runTests():
         cvar.verbose = False
 
     # move to the project file directory so all paths can be relative
+    olddir = os.getcwd()
     try:
         os.chdir(os.path.split(project_file)[0])
     except OSError:
@@ -63,8 +54,21 @@ def runTests():
     test = ClassificationTaskManager(project_file)
     test.run()
 
+    try:
+        os.chdir(olddir)
+    except OSError:
+        pass
 
 if __name__ == '__main__':
-    runTests()
+    parser = OptionParser(usage = '%prog [options] project_file')
 
+    options, args = parser.parse_args()
+
+    try:
+        project_file = args[0]
+    except:
+        parser.print_help()
+        sys.exit(1)
+
+    runTests(project_file)
 

--- a/src/bindings/pygaia/scripts/classification/select_best_model.py
+++ b/src/bindings/pygaia/scripts/classification/select_best_model.py
@@ -15,30 +15,17 @@
 # FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
 # details.
 #
-# You should have received a copy of the Affero GNU General Public License     
+# You should have received a copy of the Affero GNU General Public License
 # version 3 along with this program. If not, see http://www.gnu.org/licenses/
 
 import sys, os.path, shutil
 from gaia2.fastyaml import yaml
 from get_classification_results import ClassificationResults
-from generate_svm_history_from_config import trainSVMHistory 
+from generate_svm_history_from_config import trainSVMHistory
 from gaia2.classification import ConfusionMatrix
 from optparse import OptionParser
 
-
-def selectBestModel():
-
-    parser = OptionParser(usage = '%prog [options] project_file results_model_file')
-
-    options, args = parser.parse_args()
-
-    try:
-        project_file = args[0]
-        results_model_file = args[1]
-    except:
-        parser.print_help()
-        sys.exit(1)
-
+def selectBestModel(project_file, results_model_file):
     f = open(results_model_file + '.results.html', 'w')
 
     project = yaml.load(open(project_file, 'r'))
@@ -60,9 +47,9 @@ def selectBestModel():
         cm = ConfusionMatrix()
         cm.load(filename)
         f.write(cm.toHtml())
-        
+
         filename = filename.replace('.result', '.param')
-    
+
         trainSVMHistory(project_file, filename, results_model_file, className)
         shutil.copyfile(filename, results_model_file + '.param')
 
@@ -72,4 +59,15 @@ def selectBestModel():
 
 
 if __name__ == '__main__':
-    selectBestModel()
+    parser = OptionParser(usage = '%prog [options] project_file results_model_file')
+
+    options, args = parser.parse_args()
+
+    try:
+        project_file = args[0]
+        results_model_file = args[1]
+    except:
+        parser.print_help()
+        sys.exit(1)
+
+    selectBestModel(project_file, results_model_file)


### PR DESCRIPTION
Previous the model training scripts had a single method that got arguments from sys.argv. Scripts that wanted to call another script set sys.argv and then called this method.
I've changed the methods to take the correct number of arguments and moved arg parsing into the main stub