### PR TITLE
changed point.h to ../point.h

### DIFF
--- a/src/parser/parsertypes.h
+++ b/src/parser/parsertypes.h
@@ -21,7 +21,7 @@
 #define GAIA_PARSER_PARSERTYPES_H
 
 #include <QList>
-#include "filter.h"
+#include "../point.h"
 #include "grammar.h"
 
 namespace gaia2 {

--- a/src/parser/parsertypes.h
+++ b/src/parser/parsertypes.h
@@ -21,7 +21,7 @@
 #define GAIA_PARSER_PARSERTYPES_H
 
 #include <QList>
-#include "point.h"
+#include "filter.h"
 #include "grammar.h"
 
 namespace gaia2 {


### PR DESCRIPTION
Fixes compilation error with waf 

* Changes made to src/parser/parsertypes.h
* parsertypes.h contains headerfile #include "point.h"
* There is no file as point.h
* Changed #include "point.h" to #include "../point.h"
 