### PR TITLE
Fixed bug for invalid dir management in classification

### DIFF
--- a/src/bindings/pygaia/scripts/classification/train_model_from_sigs.py
+++ b/src/bindings/pygaia/scripts/classification/train_model_from_sigs.py
@@ -19,9 +19,13 @@ def get_files_in_dir(dirname, extension):
     return glob.glob(os.path.join(dirname, "*.%s" % extension))
 
 def main(dirname, options):
-    print "running in dir", dirname
-    project_dir = os.path.abspath(dirname)
-    projname = os.path.basename(dirname)
+    if os.path.isdir(dirname):
+        print "running in dir", dirname
+        project_dir = os.path.abspath(dirname)
+        projname = os.path.basename(project_dir)
+    else:
+        print("Invalid directory: " + dirname)
+        sys.exit(2)
 
     # if config/results exist, need force to rm them
     project_file = os.path.join(project_dir, "%s.project" % projname)


### PR DESCRIPTION
When launching train_model_from_sigs.py if invalid directory name is provided, the program does not crash nor prevent the user. Moreover if a valid relative path if provided the same behavior occur.
Simple fix to manage the validity of the directory name and the relative path.