### PR TITLE
Fix build under GCC 6.3.0

### DIFF
--- a/wscript
+++ b/wscript
@@ -86,7 +86,7 @@ def configure(conf):
     conf.env.APP_VERSION = VERSION
 
     # compiler flags
-    conf.env.CXXFLAGS += [ '-Wall', '-fno-strict-aliasing', '-fPIC', '-fvisibility=hidden' ]
+    conf.env.CXXFLAGS += [ '-std=c++03', '-Wall', '-fno-strict-aliasing', '-fPIC', '-fvisibility=hidden' ]
 
     # define this to be stricter, but sometimes some libraries can give problems...
     #conf.env.CXXFLAGS += [ '-Werror' ]


### PR DESCRIPTION
GCC 6.3.0 forces C++11 by default, and it's causes some build errors in Eigen and gaia2.

```
../src/metrics/frozencosineangledistance.h:30:48: error: ‘constexpr’ needed for in-class initialization of static data member ‘const Real gaia2::FrozenCosineAngleDistance::defaultUndefinedDistance’ of non-integral type [-fpermissive]
   static const Real defaultUndefinedDistance = 0.0;
```

```
/home/a1ba/projects/essentia/gaia/src/3rdparty/Eigen/src/Core/util/Macros.h:252:35: error: unable to find string literal operator ‘operator""X’ with ‘const char [2]’, ‘long unsigned int’ arguments
 #define EIGEN_ASM_COMMENT(X)  asm("#"X)
                                   ^
/home/a1ba/projects/essentia/gaia/src/3rdparty/Eigen/src/Core/products/GeneralBlockPanelKernel.h:640:1: note: in expansion of macro ‘EIGEN_ASM_COMMENT’
 EIGEN_ASM_COMMENT("myend");
```