### PR TITLE
Switch to Python 3

### DIFF
--- a/src/bindings/parameter.i
+++ b/src/bindings/parameter.i
@@ -16,7 +16,7 @@ PyObject* parameterToPython(const QVariant* p) {
 
   case QVariant::ByteArray: {
     QByteArray array = p->toByteArray();
-    result = PyString_FromStringAndSize(array.data(), array.size());
+    result = PyBytes_FromStringAndSize(array.data(), array.size());
     break;
   }
 

--- a/src/bindings/wscript
+++ b/src/bindings/wscript
@@ -26,7 +26,7 @@ def configure(conf):
         if conf.check_swig_version() < (1,3,31):
             conf.fatal('this swig version is too old')
 
-        conf.check_python_version((2,4))
+        conf.check_python_version((3,5))
         conf.check_python_headers()
 
         # do not use the default extension of .bundle on MacOS


### PR DESCRIPTION
Building with Python 3 binding would fail due to wrong method in the interface file: PyString_FromStringAndSize (current) is for Python 2 and should be replaced for PyBytes_FromStringAndSize

This breaks compatibility with Python 2. For this reason, the minimum required python version in wscript check is forced to be 3.5.

We should merge this once it is decided and approved to drop Python 2. Of course we could have tried to maintain Python 2, but it is 2020 (@ffont, @alastair, please confirm Freesound status). 