### PR TITLE
Fix Qt5 paths in pkg-config file

### DIFF
--- a/wscript
+++ b/wscript
@@ -116,9 +116,6 @@ def configure(conf):
         conf.env.LINKFLAGS = [ '-stdlib=libc++' ]
         # for defining static const variables in header
         conf.env.CXXFLAGS += [ '-Wno-static-float-init' ]
-        # add /usr/local/include as the brew formula for yaml doesn't have
-        # the cflags properly set
-        conf.env.CXXFLAGS += [ '-I/usr/local/include' ]
 
     if conf.options.CROSS_COMPILE_MINGW32:
         #print("- Cross-compiling for Windows with MinGW: search for pre-built dependencies in 'packaging/win32_3rdparty'")

--- a/wscript
+++ b/wscript
@@ -176,14 +176,15 @@ def configure(conf):
         Name: libgaia2
         Description: A library for doing similarity in semimetric spaces
         Version: %(version)s
-        Libs: -L${libdir} -L${qtlibdir} -lgaia2 -lQtCore -lyaml %(tbblib)s
+        Libs: -L${libdir} -L${qtlibdir} -lgaia2 -lQt5Core -lQt5Concurrent -lyaml %(tbblib)s
         Cflags: -I${includedir} ${qtincludes}
         ''' % opts
 
     elif sys.platform == 'darwin':
         opts = { 'prefix': prefix,
              'qtlibdir': '-F' + conf.env['FRAMEWORKPATH_QT5CORE'][0] +
-                         ' -framework ' + conf.env['FRAMEWORK_QT5CORE'][0],
+                         ' -framework ' + conf.env['FRAMEWORK_QT5CORE'][0] +
+                         ' -framework ' + conf.env['FRAMEWORK_QT5CONCURRENT'][0],
              'qtincludedir': '-I' + ' -I'.join(conf.env['INCLUDES_QT5CORE']),
              'version': VERSION,
              'tbblib': tbblib,


### PR DESCRIPTION
The generated gaia2.pc file was apparently forgotten during the upgrade to Qt5. I also took the liberty of removing an outdated workaround: the libyaml issue has now been corrected in homebrew.