### PR TITLE
Update python 3 string classes in bindings

### DIFF
--- a/src/bindings/frozendataset.i
+++ b/src/bindings/frozendataset.i
@@ -52,7 +52,7 @@ class FrozenLayout(object):
         if pattern in (StringType, EnumType):
             return []
 
-        if isinstance(pattern, basestring):
+        if isinstance(pattern, str):
             pattern = pattern.lower()
             # try to be a bit lenient here by allowing to not specify the namespace of a descriptor
             if pattern[0] not in ('*', '.'):
@@ -149,7 +149,7 @@ class FrozenPoint(tuple):
         raise NotImplementedError()
 
     def __getitem__(self, desc):
-        if isinstance(desc, basestring):
+        if isinstance(desc, str):
             region = self.layout().descriptorLocation(desc)
             return self[region[0]:region[1]]
 

--- a/src/bindings/pythonic.i
+++ b/src/bindings/pythonic.i
@@ -21,14 +21,8 @@ def pmap(param_map):
 
     pm = ParameterMap()
     for key, value in param_map.items():
-        if not isinstance(key, basestring):
+        if not isinstance(key, str):
             raise TypeError('A key in the map is not a string; can not convert it')
-
-        # until python 3, everything should always be utf-8 encoded bytestrings
-        if isinstance(key, unicode):
-            key = key.encode('utf-8')
-        if isinstance(value, unicode):
-            value = value.encode('utf-8')
 
         if isinstance(value, (dict, ParameterMap)): # if value is a python map, convert it to ParameterMap
             pm.setParameterMap(key, pmap(value))

--- a/test/scratch/classification/ntuple.py
+++ b/test/scratch/classification/ntuple.py
@@ -55,7 +55,7 @@ def namedtuple(typename, field_names, verbose=False, rename=False):
 
     # Parse and validate the field names.  Validation serves two purposes,
     # generating informative error messages and preventing template injection attacks.
-    if isinstance(field_names, basestring):
+    if isinstance(field_names, str):
         field_names = field_names.replace(',', ' ').split() # names separated by whitespace and/or commas
     field_names = tuple(map(str, field_names))
     if rename:


### PR DESCRIPTION
in #94 we switched to python 3 only in the bindings, but some code still used `basestring` which is python2-only. Update it to use `str`. Remove one place which encoded strings to bytes as this is no longer needed.
I tested the end-to-end process of training a model and it works fine. 