### PR TITLE
Add GaiaException in python bindings to capture C++ exception

### DIFF
--- a/src/bindings/gaia.swig
+++ b/src/bindings/gaia.swig
@@ -46,6 +46,10 @@ namespace std {
   try {
     $action
   }
+  catch (GaiaException& e) {
+    PyErr_SetString(gaiaException, e.what());
+    SWIG_fail;
+  }
   catch (std::exception& e) {
     PyErr_SetString(PyExc_Exception, e.what());
     SWIG_fail;
@@ -103,7 +107,7 @@ inline std::vector<std::vector<double> > covarianceMatrix(const gaia2::DataSet* 
 // declare this here, definition is in parameter.i
 PyObject* parameterToPython(const QVariant* p);
 PyObject* pmapToPython(const ParameterMap* pm);
-
+static PyObject* gaiaException;
 %}
 
 %include "../gaia.h"
@@ -123,6 +127,9 @@ PyObject* pmapToPython(const ParameterMap* pm);
 
 %init %{
   init();
+  gaiaException = PyErr_NewException("_gaia.GaiaException", NULL, NULL);
+  Py_INCREF(gaiaException);
+  PyModule_AddObject(m, "GaiaException", gaiaException);
 %}
 
 

--- a/src/bindings/pythonic.i
+++ b/src/bindings/pythonic.i
@@ -8,6 +8,7 @@ import sys
 import os.path
 
 __version__ = _gaia2.cvar.version
+GaiaException = _gaia2.GaiaException
 
 #### ParameterMap and Factories adjustments ###################################
 
@@ -169,10 +170,10 @@ def autoSetValue(p, name, value):
 def autoGetValue(p, name):
     try:
         return p.value(name)
-    except:
+    except GaiaException:
         try:
             return p.label(name)
-        except:
+        except GaiaException:
             raise NameError('Descriptor %s doesn\'t exist' % name)
 
 Point.__getitem__ = autoGetValue

--- a/src/bindings/pythonic.i
+++ b/src/bindings/pythonic.i
@@ -153,14 +153,6 @@ addChildRef(View, '__init__')
 
 #### API pythonization ########################################################
 
-try:
-    all
-except NameError:
-    def all(l):
-        if l == []:
-            return True
-        return l[0] and all(l[1:])
-
 def autoSetValue(p, name, value):
     if isinstance(value, str) or (isinstance(value, list) and all([ isinstance(item, str) for item in value ])):
         p.setLabel(name, value)


### PR DESCRIPTION
Fixes #22 

Previously, all C++ exceptions were being rased in python as the base Exception type, making it difficult to capture an error that came from gaia. Create a new type that is exposed in python and can be caught.

before this change:
```
>>> p = gaia2.Point('foo', pl)
>>> p['foo']
Traceback (most recent call last):
  File "/usr/local/lib/python3/dist-packages/gaia2/__init__.py", line 5327, in autoGetValue
    return p.value(name)
  File "/usr/local/lib/python3/dist-packages/gaia2/__init__.py", line 4175, in value
    result = self._value(*args)
  File "/usr/local/lib/python3/dist-packages/gaia2/__init__.py", line 4172, in _value
    return _gaia2.Point__value(self, *args)
Exception: Couldn't find node with name 'foo'
```

after this change:
```
>>> p.value('x')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3/dist-packages/gaia2/__init__.py", line 4175, in value
    result = self._value(*args)
  File "/usr/local/lib/python3/dist-packages/gaia2/__init__.py", line 4172, in _value
    return _gaia2.Point__value(self, *args)
_gaia.GaiaException: Couldn't find node with name 'x'
```

```
>>> try:
...     p.value('x')
... except gaia2.GaiaException:
...     print("caught an error")
...
caught an error
```