### PR TITLE
Arch Linux build, packaging, and install

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,21 @@ Dependencies:
 
       python src/doc/regenerate_docstring.py
 
+#### Arch Linux
+
+On Arch Linux the Arch User Repository PKGBUILD can be used to build, package, and install:
+
+```shell
+cd packaging/aur
+makepkg
+sudo pacman -U gaia-<version>-<release>-<architecture>.pkg.tar.zst
+```
+
+To uninstall on Arch Linux:
+
+```shell
+sudo pacman -R gaia
+```
 
 ### MacOS
 

--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ On Arch Linux the Arch User Repository PKGBUILD can be used to build, package, a
 ```shell
 cd packaging/aur
 makepkg
-sudo pacman -U gaia-<version>-<release>-<architecture>.pkg.tar.zst
+sudo pacman -U libgaia2-<version>-<release>-<architecture>.pkg.tar.zst
 ```
 
 To uninstall on Arch Linux:
 
 ```shell
-sudo pacman -R gaia
+sudo pacman -R libgaia2
 ```
 
 ### MacOS

--- a/packaging/aur/.SRCINFO
+++ b/packaging/aur/.SRCINFO
@@ -1,0 +1,19 @@
+pkgbase = gaia
+	pkgdesc =  C++ library with python bindings which implements similarity measures and classifcations on the results of audio analysis, and generates classifcation models that Essentia can use to compute high-level description of music.
+	pkgver = v2.4.6
+	pkgrel = 1
+	url = https://github.com/MTG/gaia
+	arch = x86_64
+	arch = armv7h
+	license = AGPL3
+	makedepends = eigen
+	makedepends = git
+	makedepends = libyaml
+	makedepends = pkg-config
+	makedepends = python
+	makedepends = qt5-base
+	makedepends = swig
+	source = gaia::git+https://github.com/MTG/gaia.git
+	sha256sums = SKIP
+
+pkgname = gaia

--- a/packaging/aur/.SRCINFO
+++ b/packaging/aur/.SRCINFO
@@ -2,7 +2,7 @@ pkgbase = gaia
 	pkgdesc =  C++ library with python bindings which implements similarity measures and classifcations on the results of audio analysis, and generates classifcation models that Essentia can use to compute high-level description of music.
 	pkgver = v2.4.6r2
 	pkgrel = 1
-	url = https://github.com/MTG/gaia
+	url = https://github.com/doctorfree/gaia
 	arch = x86_64
 	arch = armv7h
 	license = AGPL3
@@ -13,7 +13,7 @@ pkgbase = gaia
 	makedepends = python
 	makedepends = qt5-base
 	makedepends = swig
-	source = gaia::git+https://github.com/MTG/gaia.git
+	source = gaia::git+https://github.com/doctorfree/gaia.git
 	sha256sums = SKIP
 
 pkgname = gaia

--- a/packaging/aur/.SRCINFO
+++ b/packaging/aur/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = gaia
 	pkgdesc =  C++ library with python bindings which implements similarity measures and classifcations on the results of audio analysis, and generates classifcation models that Essentia can use to compute high-level description of music.
-	pkgver = v2.4.6
+	pkgver = v2.4.6r2
 	pkgrel = 1
 	url = https://github.com/MTG/gaia
 	arch = x86_64

--- a/packaging/aur/.SRCINFO
+++ b/packaging/aur/.SRCINFO
@@ -1,4 +1,4 @@
-pkgbase = gaia
+pkgbase = libgaia2
 	pkgdesc =  C++ library with python bindings which implements similarity measures and classifcations on the results of audio analysis, and generates classifcation models that Essentia can use to compute high-level description of music.
 	pkgver = v2.4.6r2
 	pkgrel = 1
@@ -16,4 +16,4 @@ pkgbase = gaia
 	source = gaia::git+https://github.com/doctorfree/gaia.git
 	sha256sums = SKIP
 
-pkgname = gaia
+pkgname = libgaia2

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -1,0 +1,53 @@
+# Maintainer: Ronald Record <github@ronrecord.com>
+
+pkgname=gaia
+pkgver=v2.4.6r1
+pkgrel=1
+pkgdesc="C++ library with python bindings which implements similarity measures and classifcations on the results of audio analysis, and generates classifcation models that Essentia can use to compute high-level description of music."
+arch=('x86_64' 'armv7h')
+url="https://github.com/doctorfree/gaia"
+license=('AGPL3')
+makedepends=(eigen git libyaml pkg-config python qt5-base swig)
+source=("${pkgname}::git+https://github.com/doctorfree/gaia.git#tag=${pkgver}")
+sha256sums=('SKIP')
+
+prepare() {
+  cd "${srcdir}/${pkgname}"
+    # Prior to configure, determine SSE2 support and set CXXFLAGS
+    grep sse2 /proc/cpuinfo > /dev/null || {
+      # Remove -msse2 from CXXFLAGS
+      cat wscript | sed -e "s/'-O2', '-msse2'/'-O2'/" > /tmp/wsc$$
+      cp /tmp/wsc$$ wscript
+      rm -f /tmp/wsc$$
+    }
+}
+
+build() {
+  cd "${srcdir}/${pkgname}"
+  # Build gaia
+  ./waf configure --prefix=/usr --with-python-bindings --with-asserts
+  ./waf
+}
+
+package() {
+  cd "${srcdir}/${pkgname}"
+  ./waf install --destdir="${pkgdir}"
+
+  destdir=usr
+  [ -d ${pkgdir}/${destdir}/share ] || {
+    mkdir -p ${pkgdir}/${destdir}/share
+  }
+  [ -d ${pkgdir}/${destdir}/share/doc ] || {
+    mkdir -p ${pkgdir}/${destdir}/share/doc
+  }
+  [ -d ${pkgdir}/${destdir}/share/doc/${pkgname} ] || {
+    mkdir -p ${pkgdir}/${destdir}/share/doc/${pkgname}
+  }
+  cp AUTHORS ${pkgdir}/${destdir}/share/doc/${pkgname}
+  cp Changelog ${pkgdir}/${destdir}/share/doc/${pkgname}
+  cp COPYING.txt ${pkgdir}/${destdir}/share/doc/${pkgname}
+  cp README.md ${pkgdir}/${destdir}/share/doc/${pkgname}
+  cp VERSION ${pkgdir}/${destdir}/share/doc/${pkgname}
+  gzip -9 ${pkgdir}/${destdir}/share/doc/${pkgname}/Changelog
+  chmod 755 ${pkgdir}/${destdir}/bin/* ${pkgdir}/${destdir}/bin
+}

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Ronald Record <github@ronrecord.com>
 
-pkgname=gaia
+pkgname=libgaia2
 pkgver=v2.4.6r2
 pkgrel=1
 pkgdesc="C++ library with python bindings which implements similarity measures and classifcations on the results of audio analysis, and generates classifcation models that Essentia can use to compute high-level description of music."

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Ronald Record <github@ronrecord.com>
 
 pkgname=gaia
-pkgver=v2.4.6r1
+pkgver=v2.4.6r2
 pkgrel=1
 pkgdesc="C++ library with python bindings which implements similarity measures and classifcations on the results of audio analysis, and generates classifcation models that Essentia can use to compute high-level description of music."
 arch=('x86_64' 'armv7h')
@@ -44,10 +44,10 @@ package() {
     mkdir -p ${pkgdir}/${destdir}/share/doc/${pkgname}
   }
   cp AUTHORS ${pkgdir}/${destdir}/share/doc/${pkgname}
-  cp Changelog ${pkgdir}/${destdir}/share/doc/${pkgname}
+  cp ChangeLog ${pkgdir}/${destdir}/share/doc/${pkgname}
   cp COPYING.txt ${pkgdir}/${destdir}/share/doc/${pkgname}
   cp README.md ${pkgdir}/${destdir}/share/doc/${pkgname}
   cp VERSION ${pkgdir}/${destdir}/share/doc/${pkgname}
-  gzip -9 ${pkgdir}/${destdir}/share/doc/${pkgname}/Changelog
+  gzip -9 ${pkgdir}/${destdir}/share/doc/${pkgname}/ChangeLog
   chmod 755 ${pkgdir}/${destdir}/bin/* ${pkgdir}/${destdir}/bin
 }

--- a/packaging/aur/README.md
+++ b/packaging/aur/README.md
@@ -12,11 +12,11 @@ makepkg
 After successfully building, to install:
 
 ```shell
-sudo pacman -U gaia-<version>-<release>-<architecture>.pkg.tar.zst
+sudo pacman -U libgaia2-<version>-<release>-<architecture>.pkg.tar.zst
 ```
 
 To uninstall:
 
 ```shell
-sudo pacman -R gaia
+sudo pacman -R libgaia2
 ```

--- a/packaging/aur/README.md
+++ b/packaging/aur/README.md
@@ -12,5 +12,11 @@ makepkg
 After successfully building, to install:
 
 ```shell
-sudo pacman -U <package_file>
+sudo pacman -U gaia-<version>-<release>-<architecture>.pkg.tar.zst
+```
+
+To uninstall:
+
+```shell
+sudo pacman -R gaia
 ```

--- a/packaging/aur/README.md
+++ b/packaging/aur/README.md
@@ -1,0 +1,16 @@
+# Arch Linux AUR packaging
+
+This directory contains the packaging files for the Arch User Repository.
+See https://wiki.archlinux.org/title/Arch_User_Repository
+
+To build on Arch Linux, in this directory issue the command:
+
+```shell
+makepkg
+```
+
+After successfully building, to install:
+
+```shell
+sudo pacman -U <package_file>
+```

--- a/packaging/aur/makepkg.conf
+++ b/packaging/aur/makepkg.conf
@@ -1,0 +1,46 @@
+#!/hint/bash
+#
+#########################################################################
+# GLOBAL PACKAGE OPTIONS
+#   These are default values for the options=() settings
+#########################################################################
+#
+# Makepkg defaults: OPTIONS=(!strip docs libtool staticlibs emptydirs !zipman !purge !debug !lto)
+#  A negated option will do the opposite of the comments below.
+#
+#-- strip:      Strip symbols from binaries/libraries
+#-- docs:       Save doc directories specified by DOC_DIRS
+#-- libtool:    Leave libtool (.la) files in packages
+#-- staticlibs: Leave static library (.a) files in packages
+#-- emptydirs:  Leave empty directories in packages
+#-- zipman:     Compress manual (man and info) pages in MAN_DIRS with gzip
+#-- purge:      Remove files specified by PURGE_TARGETS
+#-- debug:      Add debugging flags as specified in DEBUG_* variables
+#-- lto:        Add compile flags for building with link time optimization
+#
+OPTIONS=(strip docs !libtool !staticlibs emptydirs zipman purge !debug !lto)
+#
+#-- Compiler and Linker Flags
+#CPPFLAGS=""
+#CFLAGS="-march=native -O2 -pipe -fno-plt -fexceptions \
+#        -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security \
+#        -fstack-clash-protection -fcf-protection"
+#CXXFLAGS="$CFLAGS -Wp,-D_GLIBCXX_ASSERTIONS"
+#########################################################################
+# PACKAGE OUTPUT
+#########################################################################
+#
+# Default: put built package and cached source in build directory
+#
+#-- Destination: specify a fixed directory where all packages will be placed
+#PKGDEST=/home/doctorwhen/packages
+#-- Source cache: specify a fixed directory where source files will be cached
+#SRCDEST=/home/doctorwhen/sources
+#-- Source packages: specify a fixed directory where all src packages will be placed
+#SRCPKGDEST=/home/doctorwhen/srcpackages
+#-- Log files: specify a fixed directory where all log files will be placed
+#LOGDEST=/home/doctorwhen/makepkglogs
+#-- Packager: name/email of the person or organization building packages
+PACKAGER="Ronald Record <ronaldrecord@gmail.com>"
+#-- Specify a key to use for package signing
+#GPGKEY=""


### PR DESCRIPTION
This Pull Request contains build and packaging files for Arch Linux in `packaging/aur/`. These are `PKGBUILD` files used on Arch Linux by `makepkg` to build and create an Arch Linux package installable with `pacman`.

In addition to the packaging files in `packaging/aur`, a note was added to the README.md on how to build, package, and install on Arch Linux.