### PR TITLE
README: outdated qt version / mac instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,14 +54,9 @@ Dependencies:
 ### MacOS
 
 #### Build from command-line using Homebrew (recommended):
-- Install Qt4:
-
-      brew install cartr/qt4/qt
-
 - Install homebrew tap:
 
       brew tap MTG/essentia
-
 
 - Build Gaia (this will also install all the dependencies)
 
@@ -69,11 +64,11 @@ Dependencies:
 
 #### Build from command-line:
 
-- Install python, qt libraries 4.8, libYAML and swig dependencies using [Homebrew](http://brew.sh):
+- Install python, qt libraries 5, libYAML and swig dependencies using [Homebrew](http://brew.sh):
 
       brew install python
 
-      brew install swig libyaml cartr/qt4/qt@4
+      brew install swig libyaml qt@5
 
 - Install pyyaml pip package in case you want to build with python bindings:
 


### PR DESCRIPTION
update the macOS install instructions to qt5 (since https://github.com/MTG/gaia/pull/92, and the current [homebrew tap](https://github.com/MTG/homebrew-essentia/blob/master/gaia.rb) uses it as well).

I assume the linux instructions could be updated as well, but I can't test them; feel free to edit this pull request if you'd like before merging.